### PR TITLE
Doc params

### DIFF
--- a/collections/hashmap/contracts/Hashmap.sol
+++ b/collections/hashmap/contracts/Hashmap.sol
@@ -21,7 +21,7 @@ contract Hashmap is UnsafeHashmap {
   }
 
   /**
-   * @brief      If owner or manager contract is calling function, it will get the value at a key
+   * @dev        If owner or manager contract is calling function, it will get the value at a key
    *
    * @param      _key    The key
    *
@@ -36,7 +36,7 @@ contract Hashmap is UnsafeHashmap {
   }
 
   /**
-   * @brief      If owner or manager contract is calling function, it will check existence of a key/value
+   * @dev        If owner or manager contract is calling function, it will check existence of a key/value
    *
    * @param      _key    The key
    *
@@ -51,7 +51,7 @@ contract Hashmap is UnsafeHashmap {
   }
 
   /**
-   * @brief      If owner or manager contract is calling function, it will return the size of hashmap
+   * @dev        If owner or manager contract is calling function, it will return the size of hashmap
    *
    * @return     returns size of hashmap
    */
@@ -64,9 +64,9 @@ contract Hashmap is UnsafeHashmap {
   }
 
   /**
-   * @dev Allows the current owner to transfer control of the contract to a newOwner.
+   * @dev        Allows the current owner to transfer control of the contract to a newOwner.
    *
-   * @param newOwner The address to transfer ownership to.
+   * @param      _newOwner   The address to transfer ownership to.
    *
    * @returns    returns status of ownership transfer
    */

--- a/collections/hashmap/contracts/Hashmap.sol
+++ b/collections/hashmap/contracts/Hashmap.sol
@@ -68,7 +68,7 @@ contract Hashmap is UnsafeHashmap {
    *
    * @param      _newOwner   The address to transfer ownership to.
    *
-   * @returns    returns status of ownership transfer
+   * @return     returns status of ownership transfer
    */
   function transferOwnership(address _newOwner) public returns (bool) {
     if (msg.sender != owner) {


### PR DESCRIPTION
Solidity is particular with the formatting of documentation strings. We've never had problems with them, because the parse/unparse roundtrip to add __getSource__ erased all comments outside of function bodies. Now, we compile the exact source code, and thus have to adhere to the documentation rules. I don't know where these are outlined, but this source file has the list of accepted strings for each component: https://github.com/ethereum/solidity/blob/develop/libsolidity/analysis/DocStringAnalyser.cpp