### PR TITLE
Add a solc test

### DIFF
--- a/auth/permission/contracts/PermissionedHashmap.sol
+++ b/auth/permission/contracts/PermissionedHashmap.sol
@@ -1,4 +1,3 @@
-import "../../../rest/contracts/RestStatus.sol";
 import "../../../collections/hashmap/contracts/UnsafeHashmap.sol";
 import "../../../auth/permission/contracts/PermissionManager.sol";
 

--- a/auth/permission/test/fixtures/HashmapPermissionManager.sol
+++ b/auth/permission/test/fixtures/HashmapPermissionManager.sol
@@ -1,4 +1,3 @@
-import "../../../../rest/contracts/RestStatus.sol";
 import "../../contracts/PermissionManager.sol";
 
 /**

--- a/auth/user/contracts/UserManager.sol
+++ b/auth/user/contracts/UserManager.sol
@@ -1,7 +1,6 @@
 import "./User.sol";
 import "../../../rest/contracts/RestStatus.sol";
 import "../../../collections/hashmap/contracts/Hashmap.sol";
-import "../../../util/contracts/Util.sol";
 
 /**
 * Interface for Gas Deal data contracts

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "find . -type f -name '*.test.js' ! -path './node_modules/*' | xargs mocha ",
     "test:hashmap": "mocha collections/hashmap/test/hashmap.test.js --config config.yaml -b",
     "test:permission": "mocha auth/permission-manager/test/ --config config.yaml -b --api-debug",
-    "test:user": "mocha auth/user/test/ --config config.yaml -b "
+    "test:user": "mocha auth/user/test/ --config config.yaml -b ",
+    "test:solc": "find . -name '*.sol' -print | xargs solc --allow-paths '.' 2>&1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Tests pass with 0.4.25 provided the extraneous imports are removed. Tests fail on 0.5.0 because `constant` has been superceded by `pure` and `view`, and `apply` is now a language keyword